### PR TITLE
feat: Adjust followers/follow ratio to avoid debuff

### DIFF
--- a/src/app/[handle]/score.tsx
+++ b/src/app/[handle]/score.tsx
@@ -44,7 +44,8 @@ function calculateProfileScore(profile: ProfileViewDetailed) {
 
   if (profile.followersCount && profile.followsCount) {
     // follow ratio buff
-    score *= profile.followersCount / profile.followsCount;
+    const ratio = profile.followersCount / profile.followsCount;
+    score *= ratio > 1 ? ratio : 1;
   }
 
   return Math.ceil(score);


### PR DESCRIPTION
This is just a small change to avoid debuff the users account given small the proportion of followers / follows.

This would avoid something like:
50 pts * (1000 followers / 100 follows) = 500 pts
50 pts * (100 followers / 1000 follows) = 5 pts